### PR TITLE
fix: Fix eventbridge rule

### DIFF
--- a/sagemaker_run_notebook/cloudformation-base.yml
+++ b/sagemaker_run_notebook/cloudformation-base.yml
@@ -286,7 +286,7 @@ Resources:
       Action: lambda:InvokeFunction
       FunctionName: {"Fn::Join": ["-", ["RunNotebook", {"Ref": "Environment"}]]}
       Principal: events.amazonaws.com
-      SourceArn: {"Fn::Join": [":", ["arn:aws:events", {"Ref": "AWS::Region"}, {"Ref": "AWS::AccountId"}, "rule/RunNotebook-", {"Ref": "Environment"}, '*']]}
+      SourceArn: {"Fn::Join": [":", ["arn:aws:events", {"Ref": "AWS::Region"}, {"Ref": "AWS::AccountId"}, "rule/RunNotebook-", {"Fn::Join": ["", [{"Ref": "Environment"}, "*"]]}]]}
   InvokeNotebookLambda:
     Type: AWS::Lambda::Function
     Properties:


### PR DESCRIPTION
Fixing eventbridge rule ARN. 
This has been deployed in development but needs to be done also for production.


```
❯  ENVIRONMENT=production AWS_REGION=ap-southeast-2 AWS_PROFILE=Relevance-AI.AdministratorAccess  make update-infra 
```

Please let me know if you'd like automate infra updates on Github action - however you may have to add the appropriate permissions to Github action user to do so ~

